### PR TITLE
Fix typos and add redirect to PT-BR traslation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Feel free to have a look at [Assembly x86_64](https://www.cs.uaf.edu/2017/fall/c
 
 ##### Note: To this guide, we gonna use `nasm` and `ld`. Search how to install them in you linux distribution. You can use `nasm` and `ld` manually, but I made a script to automate the building process of our executable. You dont need to use, but is there anyway. Just do the following `./simplenasm file.asm out.out`
 
+## Translations
+Leia em [PT-BR](README.pt-br.md)!
+
 # Index
    - [Basic Syntax](#basic-syntax)
    - [Sections](#basic-sections)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ lets go !!
 
 ```asm
 section .data
-   msg db "Hello, Word!!", 0xa ;Declaring_variable 
+   msg db "Hello, Wolrd!!", 0xa ;Declaring_variable 
    len equ $-msg ;Size of bytes 
 
 section .text
@@ -125,7 +125,7 @@ next we will see the instructions and their functions in the allocation.
 | --- | --- | --- |
 | DB  |	Define Byte | allocates 1 byte |
 | DW  |  Define Word	| allocates 2 bytes |
-| DD	|  Define Doublewordi | allocates 4 bytes |
+| DD	|  Define Doubleword | allocates 4 bytes |
 | DQ	|  Define Quadword |	allocates 	8 bytes |
 | DT	|  Define Ten Bytes | allocates 10 bytes |
 
@@ -137,7 +137,7 @@ choice		DB	'y'
 ```  
 it allocates characters in, 
 it can be a string like in the example of 
-"hello, word" remember?
+"hello, wolrd" remember?
 
 ----------------------------------------------------------
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -38,7 +38,7 @@ Nós as definimos usando a palavra chave `section <name>`.
 | .text | .text - seção usada para manter o código real. Essa seção deve começar com a declaração `global _start`, que informa ao *linker* o *entry point* (ponto de entrada) do programa para que então o programa começe sua execução a partir dele. |
 
 # Registradores
-Em primeiro lugar, o que é um registrador?  [`"Um registrador é um local de acesso rápido disponível para o processador de um computador. Os registros geralmente consistem em uma pequena quantidade de armazenamento rápido, embora alguns tenham funções de hardware específicas e possam ser apenas para leitura ou gravação."`](https://en.wikipedia.org/wiki/Processor_register). Mas seguindo a ideia de simplicidade, um registrador é basicamente uma "variável" de acesso rápido que você pode colocar ou remover valores.
+Em primeiro lugar, o que é um registrador?  [`"Um registrador é um local de acesso rápido disponível para o processador de um computador. Os registradores geralmente consistem em uma pequena quantidade de armazenamento rápido, embora alguns tenham funções de hardware específicas e possam ser apenas para leitura ou gravação."`](https://en.wikipedia.org/wiki/Processor_register). Mas seguindo a ideia de simplicidade, um registrador é basicamente uma "variável" de acesso rápido que você pode colocar ou remover valores.
 Na arquitetura x86, temos 8 registradores de propósito geral. Recomendo fortemente [isto](http://www.cs.virginia.edu/~evans/cs216/guides/x86.html) e [isto](https://en.wikibooks.org/wiki/X86_Assembly/X86_Architecture) para um entendimento melhor, não apenas para registradores, mas Assembly em geral.
 
 Os registradores são os seguintes:
@@ -58,9 +58,9 @@ Mas a maioria dos registradores perderam seus propósitos especiais no conjunto 
 
 # SysCalls
 
-O que é um *syscall*? Bem, um *syscall* ou chamada de sistema são APIs para a interface entre o espaço do usuário e o espaço do kernel. Já utilizamos chamadas de sistema. Vimos também registradores e a instrução `mov` respectivamente.
+O que é um *syscall*? Bem, um *syscall* ou chamada de sistema são APIs para a interface entre o espaço do usuário e o espaço do kernel. Já utilizamos chamadas de sistema anteriormente. Vimos também registradores e a instrução `mov` respectivamente.
 
-Você pode fazer uso das chamadas de sistema do Linux nos seus programas em Assembly. Você precisa seguir os seguintes passos para utiliza-las em seus programas -
+Você pode fazer uso das chamadas de sistema do Linux nos seus programas Assembly. Você precisa seguir os seguintes passos para utiliza-las em seus programas -
 
     * Coloque o número da chamada de sistema no registrador EAX.
     * Armazene os argumento para a chamada de sistema nos registradores EBX, ECX, etc.
@@ -72,12 +72,12 @@ A seguinte tabela mostra algumas das chamadas de sistema usadas nesse tutorial -
 
 |  %eax 	|  Nome 	|  %ebx 	|  %ecx 	|  %edx |   %esx  |  %edi   |
 | --- | --- | --- | --- | --- | --- | --- |
-| 1 | sys_exit  | int | - | - | - | - | 
+| 1 | sys_exit  | int | - | - | - | - |
 | 2 | sys_fork  | struct pt_regs | NULL | - | - | - |
 | 3 | sys_read  | unsigned int | char * | size_t | - | - |
-| 4 | sys_write | unsigned int | const char * | size_t | - | - | 
-| 5 | sys_open  | const char * | int | int	| - | - |
-| 6 | sys_close | unsigned int | - | - | - |  - |
+| 4 | sys_write | unsigned int | const char * | size_t | - | - |
+| 5 | sys_open  | const char * | int | int | - | - |
+| 6 | sys_close | unsigned int | - | - | - | - |
 
 vamos para o nosso primeiro código Assembly, vamos fazer uma pasta com todos os códigos usados, eles estarão na pasta `codes`!
 
@@ -104,8 +104,7 @@ Parabéns por conseguir criar seu primeiro código Assembly!
 
 
 # Types-Variables-Allocation
-Espaço de armazenamento para variáveis. 
-Storage space for variables. A pólitica de Assembly é usada para espaço de armazenamento. Pode ser usado para reservar e inicializar um ou mais bytes como ```db dw dd dq dt```.
+Espaço de armazenamento para variáveis. A pólitica de Assembly é usada para espaço de armazenamento. Pode ser usado para reservar e inicializar um ou mais bytes como ```db dw dd dq dt```.
 
 A alocação dos dados de inicialização é a seguinte.
 
@@ -120,20 +119,17 @@ A seguir nós veremos as instruções e suas funções na alocação.
 | tipo | Significado | bytes alocados |
 | --- | --- | :-: |
 | DB  | Define Byte | 1 byte |
-| DW  |  Define Word | 2 bytes |
-| DD  |  Define Doublewordi | 4 bytes |
-| DQ  |  Define Quadword | 8 bytes |
-| DT  |  Define Ten Bytes | 10 bytes |
+| DW  | Define Word | 2 bytes |
+| DD  | Define Doubleword | 4 bytes |
+| DQ  | Define Quadword | 8 bytes |
+| DT  | Define Ten Bytes | 10 bytes |
 
-O que cada um aloca: Nós veremos no exemplo a seguir.
+O que cada um aloca? Nós veremos no exemplo a seguir.
 
 ```asm
 choice		DB	'y'
 ```
-esse aloca caracteres, pode ser uma *string* como no exemplo do "hello, word" lembra?
-it allocates characters in, 
-it can be a string like in the example of 
-"hello, world" remember?
+esse aloca caracteres, pode ser uma *string* como no exemplo do "hello, word", lembra?
 
 ----------------------------------------------------------
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -5,7 +5,7 @@ para aqueles que tem dúvidas ou queiram começar.
 Neste projeto estamos cobrindo apenas sobre `Linux(ELF) Assembly Intel x86`.
 Sinta-se à vontade para dar uma olhada em [Assembly x86_64](https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html)
 
-##### Nota: Para este guia, nós iremos utilizar `nasm` e `ld`. Procure como instala-los em sua distribuição linux. Você pode utilizar o `nasm` e o `ld` manualmente, mas eu fiz um *script* para automatizar o processo de construção do nosso executavel. Você não precisa utiliza-lo, mas está lá de qualquer maneira. Apenas faça o seguinte `./simplenasm file.asm out.out`.
+##### Nota: Para este guia, nós iremos utilizar `nasm` e `ld`. Procure como instala-los em sua distribuição linux. Você pode utilizar o `nasm` e o `ld` manualmente, mas eu fiz um *script* para automatizar o processo de construção do nosso executavel. Você não precisa utiliza-lo, mas está lá de qualquer maneira. Apenas faça o seguinte `./_nasm file.asm out.out`.
 
 # Índice
    - [Sintaxe Básica](#sintaxe-básica)


### PR DESCRIPTION
I changed `word` to `world` and `doublewordi` to `doubleword` in `README.md`, some typos in `README.pt-br.md` and a redirect to read the `README.pt-br.md` in `README.md`.